### PR TITLE
#47 포지션 레벨, 포지션 이름 중복, 닉네임 중복검사

### DIFF
--- a/src/main/java/com/example/matchup/matchupbackend/controller/UserProfileController.java
+++ b/src/main/java/com/example/matchup/matchupbackend/controller/UserProfileController.java
@@ -31,11 +31,12 @@ public class UserProfileController {
     }
 
     @GetMapping("/profile/unique")
-    public ResponseEntity<Void> checkDuplicateNickname(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<Void> checkDuplicateNickname(@RequestParam("nickname") String nickname,
+                                                       @RequestHeader(value = TokenProvider.HEADER_AUTHORIZATION, required = false) String authorizationHeader) {
         if (nickname.length() > 20) {
             throw new DuplicateUserNicknameException();
         }
-        userProfileService.checkDuplicateNickname(nickname);
+        userProfileService.isPossibleNickname(nickname, authorizationHeader);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/matchup/matchupbackend/dto/request/user/AdditionalUserInfoRequest.java
+++ b/src/main/java/com/example/matchup/matchupbackend/dto/request/user/AdditionalUserInfoRequest.java
@@ -27,5 +27,5 @@ public class AdditionalUserInfoRequest {
 
     @Range(max = 100L, message = "개발자 연차는 100년을 넘거나 음수일 수 없습니다.")
     private Long expYear;
-    private Map<@Enum(enumClass = UserPositionType.class, message = "BACK, FRONT, FULL, DESIGN, AI로만 입력할 수 있습니다.") String, @Range(max = 5L, message = "스택의 범위는 0~5입니다.") Integer> userPositionLevels;
+    private Map<@Enum(enumClass = UserPositionType.class, message = "BACK, FRONT, FULL, DESIGN, AI로만 입력할 수 있습니다.") String, @Range(max = 4L, message = "스택의 범위는 0~5입니다.") Integer> userPositionLevels;
 }

--- a/src/main/java/com/example/matchup/matchupbackend/entity/User.java
+++ b/src/main/java/com/example/matchup/matchupbackend/entity/User.java
@@ -146,11 +146,6 @@ public class User extends BaseEntity implements UserDetails {
         this.refreshToken = newRefreshToken;
     }
 
-    public User updateUserLevel() {
-        this.userLevel = this.userPositions.stream().mapToLong(UserPosition::getPositionLevel).max().orElse(0L);
-        return this;
-    }
-
     public List<String> returnTagList() {
         return userTagList.stream().map(
                 userTag -> userTag.getTag().getName()
@@ -182,14 +177,15 @@ public class User extends BaseEntity implements UserDetails {
         this.recieveFeedbackList.add(feedback); // 피드백 리스트 추가
     }
 
-    public User updateFirstLogin(AdditionalUserInfoRequest request) {
+    public User updateFirstLogin(AdditionalUserInfoRequest request, List<UserPosition> userPositions) {
         this.nickname = request.getNickname();
         this.pictureUrl = request.getPictureUrl();
         this.birthDay = request.getBirthDay();
         this.expYear = request.getExpYear();
         this.isFirstLogin = false;
+        this.userPositions = userPositions;
+        this.userLevel = userPositions.stream().mapToLong(UserPosition::getPositionLevel).max().orElse(0L);
 
-        this.userLevel = updateUserLevel().getUserLevel();
         return this;
     }
 

--- a/src/main/java/com/example/matchup/matchupbackend/entity/UserPosition.java
+++ b/src/main/java/com/example/matchup/matchupbackend/entity/UserPosition.java
@@ -29,17 +29,12 @@ public class UserPosition extends BaseEntity{
 
     /**
      * 최초 로그인 시에 유저의 기술 스택을 저장하기 위해 사용
-     * @param request: AdditionalUserInfoRequest
-     * @param stack: UserPositionType
-     * @param user: User
      */
     @Builder
-    public UserPosition(AdditionalUserInfoRequest request, UserPositionType stack, User user) {
-        if (request.getUserPositionLevels().containsKey(stack)) {
-            this.positionName = stack.toString();
-            this.positionLevel = request.getUserPositionLevels().get(stack);
-            this.user = user;
-        }
+    public UserPosition(String positionName, Integer positionLevel, User user) {
+        this.positionName = positionName;
+        this.positionLevel = positionLevel;
+        this.user = user;
     }
 
 

--- a/src/main/java/com/example/matchup/matchupbackend/repository/user/UserRepository.java
+++ b/src/main/java/com/example/matchup/matchupbackend/repository/user/UserRepository.java
@@ -18,5 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     @Query("SELECT user from User user where user.id=:userID")
     Optional<User> findUserById(@Param("userID") Long userID);
 
+    Optional<User> findUserByNicknameAndIdNot(String nickname, Long userId);
+
     Optional<User> findUserByNickname(String nickname);
 }

--- a/src/main/java/com/example/matchup/matchupbackend/repository/userposition/UserPositionRepository.java
+++ b/src/main/java/com/example/matchup/matchupbackend/repository/userposition/UserPositionRepository.java
@@ -1,5 +1,6 @@
 package com.example.matchup.matchupbackend.repository.userposition;
 
+import com.example.matchup.matchupbackend.entity.User;
 import com.example.matchup.matchupbackend.entity.UserPosition;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,6 @@ import java.util.List;
 @Repository
 public interface UserPositionRepository extends JpaRepository<UserPosition, Long> {
     List<UserPosition> findByUserId(Long userId);
+
+    void deleteAllByUser(User user);
 }


### PR DESCRIPTION
 포지션 레벨 업데이트가 안되는 문제 해결
 포지션 이름이 중복되는 문제 해결: 업데이트할 때마다 포지션 밀어버리고 다시 설정
 닉네임 중복검사 시에 본인의 닉네임이 중복되는 문제 해결