### PR TITLE
#83 깃허브 액션 배포 (SCP로 jar 파일만 EC2로 전송 하는 방식)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy To SideMatch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: JDK 17버전 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: yml 파일들 만들기
+        run: |
+          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_DB_YML }}" > ./src/main/resources/application-db.yml
+          echo "${{ secrets.APPLICATION_OAUTH_YML }}" > ./src/main/resources/application-oauth.yml
+
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build
+
+      - name: 빌드된 파일 이름 변경하기
+        run: mv ./build/libs/*SNAPSHOT.jar ./sidematch.jar
+
+      - name: SCP로 EC2에 빌드된 파일 전송하기
+        uses: appleboy/scp-action@v0.1.7
+        with:
+            host: ${{ secrets.EC2_HOST }}
+            username: ${{ secrets.EC2_USERNAME }}
+            key: ${{ secrets.EC2_PRIVATE_KEY }}
+            source: sidematch.jar
+            target: /home/ubuntu/Match-Up-Backend/tobe
+
+      - name: SSH로 EC2에 접속하기
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script_stop: true
+          script: |
+            rm -rf /home/ubuntu//current
+            mkdir /home/ubuntu/Match-Up-Backend/current
+            mv /home/ubuntu/Match-Up-Backend/tobe/sidematch.jar /home/ubuntu/Match-Up-Backend/current/sidematch.jar
+            cd /home/ubuntu/instagram-server/current
+            sudo fuser -k -n tcp 8080 || true
+            nohup java -jar project.jar > ./output.log 2>&1 & 
+            rm -rf /home/ubuntu/instagram-server/tobe


### PR DESCRIPTION
- EC2 스펙이 낮아 EC2에서 빌드를 하는 것 보단 깃허브 엑션에서 빌드 후 jar 파일만 EC2로 전송하는 것이 좋다고 판단하여 SCP를 이용해  jar 파일만 EC2로 전송