### PR TITLE
#82 채팅 DB 마이그레이션 (DynamoDB 에서 MongoDB)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-dynamodb"
     implementation 'com.github.derjust:spring-data-dynamodb:5.1.0'
 
+    //MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     //웹 소캣
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // sockjs

--- a/src/main/java/com/example/matchup/matchupbackend/config/MongoDBConfig.java
+++ b/src/main/java/com/example/matchup/matchupbackend/config/MongoDBConfig.java
@@ -1,0 +1,36 @@
+package com.example.matchup.matchupbackend.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import lombok.RequiredArgsConstructor;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableMongoAuditing
+@EnableMongoRepositories(basePackages = "com.example.matchup.matchupbackend.mongodb")
+public class MongoDBConfig {
+    @Value("${spring.data.mongodb.uri}")
+    private String connectionString;
+
+    @Bean
+    public MongoClient mongoClient() {
+        CodecRegistry pojoCodecRegistry = fromProviders(PojoCodecProvider.builder().automatic(true).build());
+        CodecRegistry codecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry);
+        return MongoClients.create(MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(connectionString))
+                .codecRegistry(codecRegistry)
+                .build());
+    }
+}

--- a/src/main/java/com/example/matchup/matchupbackend/config/MongoDBConfig.java
+++ b/src/main/java/com/example/matchup/matchupbackend/config/MongoDBConfig.java
@@ -1,36 +1,14 @@
 package com.example.matchup.matchupbackend.config;
 
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoClientSettings;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
 import lombok.RequiredArgsConstructor;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.pojo.PojoCodecProvider;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableMongoAuditing
 @EnableMongoRepositories(basePackages = "com.example.matchup.matchupbackend.mongodb")
 public class MongoDBConfig {
-    @Value("${spring.data.mongodb.uri}")
-    private String connectionString;
 
-    @Bean
-    public MongoClient mongoClient() {
-        CodecRegistry pojoCodecRegistry = fromProviders(PojoCodecProvider.builder().automatic(true).build());
-        CodecRegistry codecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry);
-        return MongoClients.create(MongoClientSettings.builder()
-                .applyConnectionString(new ConnectionString(connectionString))
-                .codecRegistry(codecRegistry)
-                .build());
-    }
 }

--- a/src/main/java/com/example/matchup/matchupbackend/controller/ChatControllerV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/controller/ChatControllerV2.java
@@ -1,0 +1,42 @@
+package com.example.matchup.matchupbackend.controller;
+
+import com.example.matchup.matchupbackend.dto.response.chat.SliceChatMessageResponseV2;
+import com.example.matchup.matchupbackend.dto.response.chat.SliceChatRoomResponse;
+import com.example.matchup.matchupbackend.service.ChatServiceV2;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequestMapping("/api/v2/chat")
+@RequiredArgsConstructor
+@RestController
+public class ChatControllerV2 {
+    private final ChatServiceV2 chatService;
+
+    @PostMapping("/room/{receiverId}")
+    @Operation(description = "1대1 채팅방 생성")
+    public Long createRoomV2(@RequestHeader(value = "Authorization") String authorizationHeader, @PathVariable Long receiverId) {
+        return chatService.create1To1Room(authorizationHeader, receiverId);
+    }
+
+    @GetMapping("/room/{roomID}")
+    @Operation(description = "채팅 메세지 보기")
+    public SliceChatMessageResponseV2 showMessageV2(@RequestHeader(value = "Authorization") String authorizationHeader, @PathVariable Long roomID, Pageable pageable) {
+        return chatService.showMessages(authorizationHeader, roomID, pageable);
+    }
+
+    @GetMapping("/room")
+    @Operation(description = "채팅방 목록 보기")
+    public SliceChatRoomResponse getRoomListV2(@RequestHeader(value = "Authorization") String authorizationHeader, Pageable pageable) {
+        return chatService.getSliceChatRoomResponse(authorizationHeader, pageable);
+    }
+
+    @GetMapping("/user/{opponentId}")
+    @Operation(description = "유저와 채팅방이 이미 있는지 확인하는 API")
+    public Long checkChatRoomV2(@RequestHeader(value = "Authorization") String authorizationHeader, @PathVariable Long opponentId) {
+        return chatService.getChatRoomIdIfExist(authorizationHeader, opponentId);
+    }
+}

--- a/src/main/java/com/example/matchup/matchupbackend/controller/StompChatController.java
+++ b/src/main/java/com/example/matchup/matchupbackend/controller/StompChatController.java
@@ -2,7 +2,7 @@ package com.example.matchup.matchupbackend.controller;
 
 import com.example.matchup.matchupbackend.dto.request.chat.ChatMessageRequest;
 import com.example.matchup.matchupbackend.error.exception.InvalidValueEx.InvalidChatException;
-import com.example.matchup.matchupbackend.service.ChatService;
+import com.example.matchup.matchupbackend.service.ChatServiceV2;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StompChatController {
     private final SimpMessageSendingOperations messagingTemplate;
 
-    private final ChatService chatService;
+    private final ChatServiceV2 chatService;
 
     /**
      * 1대1 채팅 보내기

--- a/src/main/java/com/example/matchup/matchupbackend/controller/StompChatControllerV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/controller/StompChatControllerV2.java
@@ -2,12 +2,11 @@ package com.example.matchup.matchupbackend.controller;
 
 import com.example.matchup.matchupbackend.dto.request.chat.ChatMessageRequest;
 import com.example.matchup.matchupbackend.error.exception.InvalidValueEx.InvalidChatException;
-import com.example.matchup.matchupbackend.service.ChatService;
+import com.example.matchup.matchupbackend.service.ChatServiceV2;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,15 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class StompChatController {
+public class StompChatControllerV2 {
 
     private final SimpMessageSendingOperations messagingTemplate;
-    private final ChatService chatService;
+    private final ChatServiceV2 chatService;
 
     /**
-     * 1대1 채팅 보내기 : DynamoDB
+     * 1대1 채팅 보내기 : MongoDB
      */
-    @MessageMapping("/chat/{roomId}") //"pub/chat/{roomId}"
+    @MessageMapping("/mongodb/chat/{roomId}") //"pub/mongodb/chat/{roomId}"
     @SendToUser("/sub-queue/chat/{roomId}")
     public ChatMessageRequest sendMessage(@DestinationVariable Long roomId, ChatMessageRequest message) {
         if (!roomId.equals(message.getRoomId()))
@@ -33,15 +32,4 @@ public class StompChatController {
         messagingTemplate.convertAndSend("/sub-queue/chat/" + roomId, message);
         return message;
     }
-
-    /**
-     * 단체 채팅 보내기
-     */
-    @MessageMapping("/chats/{roomId}") //"pub/chats/{roomId}"
-    @SendTo("/sub-topic/chat/{roomId}")
-    public ChatMessageRequest sendMessages(@DestinationVariable Long roomId, ChatMessageRequest message) {
-        chatService.saveChatMessage(message);
-        return message;
-    }
-
 }

--- a/src/main/java/com/example/matchup/matchupbackend/dto/response/chat/ChatMessageResponseV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/dto/response/chat/ChatMessageResponseV2.java
@@ -1,0 +1,36 @@
+package com.example.matchup.matchupbackend.dto.response.chat;
+
+import com.example.matchup.matchupbackend.dto.MessageSender;
+import com.example.matchup.matchupbackend.entity.User;
+import com.example.matchup.matchupbackend.entity.UserPosition;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ChatMessageResponseV2 {
+    private MessageSender sender;
+    private String type;
+    private String message;
+    private Integer isRead;
+    private LocalDateTime sendTime;
+
+    public static ChatMessageResponseV2 from(ChatMessageV2 chatMessage, User sendUser, UserPosition senderPosition) {
+        MessageSender sender = MessageSender.builder()
+                .userId(chatMessage.getSenderID())
+                .nickname(sendUser.getNickname())
+                .pictureUrl(sendUser.getPictureUrl())
+                .level(senderPosition.getTypeLevel())
+                .build();
+        return ChatMessageResponseV2.builder()
+                .sender(sender)
+                .type(chatMessage.getMessageType())
+                .message(chatMessage.getMessage())
+                .isRead(chatMessage.getIsRead())
+                .sendTime(chatMessage.getSendTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/matchup/matchupbackend/dto/response/chat/SliceChatMessageResponseV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/dto/response/chat/SliceChatMessageResponseV2.java
@@ -1,0 +1,37 @@
+package com.example.matchup.matchupbackend.dto.response.chat;
+
+import com.example.matchup.matchupbackend.entity.User;
+import com.example.matchup.matchupbackend.entity.UserPosition;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+public class SliceChatMessageResponseV2 {
+    private List<ChatMessageResponseV2> chatMessageResponseList;
+    private int size;
+    private Boolean hasNextSlice;
+    private Long myId;
+
+    /**
+     * ChatMessage Entity에서 DTO로 변경 하여 전송
+     */
+    public static SliceChatMessageResponseV2 from(Long myId, Slice<ChatMessageV2> slice, User opponent, UserPosition userPosition) {
+        List<ChatMessageResponseV2> content = new ArrayList<>();
+        slice.getContent().forEach(chatMessage -> {
+            content.add(ChatMessageResponseV2.from(chatMessage, opponent, userPosition));
+        });
+
+        return SliceChatMessageResponseV2.builder()
+                .chatMessageResponseList(content)
+                .size(slice.getSize())
+                .hasNextSlice(slice.hasNext())
+                .myId(myId)
+                .build();
+    }
+}

--- a/src/main/java/com/example/matchup/matchupbackend/dynamodb/ChatMessageRepository.java
+++ b/src/main/java/com/example/matchup/matchupbackend/dynamodb/ChatMessageRepository.java
@@ -1,11 +1,61 @@
 package com.example.matchup.matchupbackend.dynamodb;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-@EnableScan
-public interface ChatMessageRepository extends CrudRepository<ChatMessage, String> {
-    List<ChatMessage> findByRoomId(Long roomId);
+@Repository
+public class ChatMessageRepository {
+
+    private final DynamoDBMapper dynamoDBMapper;
+
+    @Autowired
+    public ChatMessageRepository(DynamoDBMapper dynamoDBMapper) {
+        this.dynamoDBMapper = dynamoDBMapper;
+    }
+
+    public ChatMessage save(ChatMessage chatMessage) {
+        dynamoDBMapper.save(chatMessage);
+        return chatMessage;
+    }
+
+    public List<ChatMessage> saveAll(List<ChatMessage> chatMessages) {
+        dynamoDBMapper.batchSave(chatMessages);
+        return chatMessages;
+    }
+
+    public ChatMessage findById(String id) {
+        return dynamoDBMapper.load(ChatMessage.class, id);
+    }
+
+    public List<ChatMessage> findAll() {
+        return dynamoDBMapper.scan(ChatMessage.class, new DynamoDBScanExpression());
+    }
+
+    public void deleteById(String id) {
+        ChatMessage chatMessage = dynamoDBMapper.load(ChatMessage.class, id);
+        if (chatMessage != null) {
+            dynamoDBMapper.delete(chatMessage);
+        }
+    }
+
+    public List<ChatMessage> findByRoomId(Long roomId) {
+        Map<String, AttributeValue> eav = new HashMap<>();
+        eav.put(":roomId", new AttributeValue().withN(roomId.toString()));
+
+        DynamoDBQueryExpression<ChatMessage> queryExpression = new DynamoDBQueryExpression<ChatMessage>()
+                .withIndexName("RoomId-index") // 인덱스가 존재한다는 가정
+                .withConsistentRead(false)
+                .withKeyConditionExpression("roomId = :roomId")
+                .withExpressionAttributeValues(eav);
+
+        return dynamoDBMapper.query(ChatMessage.class, queryExpression);
+    }
 }

--- a/src/main/java/com/example/matchup/matchupbackend/entity/ChatRoom.java
+++ b/src/main/java/com/example/matchup/matchupbackend/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package com.example.matchup.matchupbackend.entity;
 
 import com.example.matchup.matchupbackend.dynamodb.ChatMessage;
 import com.example.matchup.matchupbackend.error.exception.InvalidValueEx.InvalidChatException;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -55,5 +56,22 @@ public class ChatRoom extends BaseEntity{
 
     private ChatMessage findLastChatMessage(List<ChatMessage> chatMessageList) {
         return chatMessageList.stream().max(Comparator.comparing(ChatMessage::getSendTime)).orElseThrow(() -> new InvalidChatException("채팅방에 메세지가 없습니다."));
+    }
+
+    /**
+     * MongoDB로 마이그레이션 - V2
+     */
+
+    public void updateRoomInfoV2(List<ChatMessageV2> chatMessageList) {
+        updateLastChatInfoV2(findLastChatMessageV2(chatMessageList));
+    }
+
+    private void updateLastChatInfoV2(ChatMessageV2 chatMessage) {
+        this.lastChat = chatMessage.getMessage();
+        this.lastChatTime = chatMessage.getSendTime();
+    }
+
+    private ChatMessageV2 findLastChatMessageV2(List<ChatMessageV2> chatMessageList) {
+        return chatMessageList.stream().max(Comparator.comparing(ChatMessageV2::getSendTime)).orElseThrow(() -> new InvalidChatException("채팅방에 메세지가 없습니다."));
     }
 }

--- a/src/main/java/com/example/matchup/matchupbackend/entity/UserChatRoom.java
+++ b/src/main/java/com/example/matchup/matchupbackend/entity/UserChatRoom.java
@@ -1,6 +1,7 @@
 package com.example.matchup.matchupbackend.entity;
 
 import com.example.matchup.matchupbackend.dynamodb.ChatMessage;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -51,6 +52,10 @@ public class UserChatRoom {
     }
 
     public void updateRoomInfo(Long myId, List<ChatMessage> chatMessageList){
+        this.unreadChatCount = chatMessageList.stream().filter(chatMessage -> chatMessage.getIsRead() == 0 && !chatMessage.getSenderID().equals(myId)).count();
+    }
+
+    public void updateRoomInfoV2(Long myId, List<ChatMessageV2> chatMessageList){
         this.unreadChatCount = chatMessageList.stream().filter(chatMessage -> chatMessage.getIsRead() == 0 && !chatMessage.getSenderID().equals(myId)).count();
     }
 }

--- a/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2.java
@@ -40,6 +40,8 @@ public class ChatMessageV2 {
         return ChatMessageV2.builder()
                 .roomId(chatMessageRequest.getRoomId())
                 .message(chatMessageRequest.getMessage())
+                .isRead(0)
+                .sendTime(LocalDateTime.now())
                 .messageType(chatMessageRequest.getType().getValue())
                 .senderID(chatMessageRequest.getSender().getUserId())
                 .build();
@@ -49,6 +51,8 @@ public class ChatMessageV2 {
         return ChatMessageV2.builder()
                 .roomId(roomId)
                 .message(roomMaker.getNickname() + "님이 채팅방을 개설하였습니다.")
+                .isRead(0)
+                .sendTime(LocalDateTime.now())
                 .messageType("ENTER")
                 .senderID(roomMaker.getId())
                 .build();

--- a/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2.java
@@ -1,0 +1,60 @@
+package com.example.matchup.matchupbackend.mongodb;
+
+import com.example.matchup.matchupbackend.dto.request.chat.ChatMessageRequest;
+import com.example.matchup.matchupbackend.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.MongoId;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "chatMessage")
+public class ChatMessageV2 {
+    @MongoId
+    private String chatId;
+    private Long roomId;
+    private String message;
+    private Integer isRead;
+    private LocalDateTime sendTime;
+    private String messageType;
+    private Long senderID;
+
+    @Builder
+    public ChatMessageV2(Long roomId, String message, Integer isRead, LocalDateTime sendTime, String messageType, Long senderID) {
+        this.chatId = UUID.randomUUID().toString();
+        this.roomId = roomId;
+        this.message = message;
+        this.isRead = isRead;
+        this.sendTime = sendTime;
+        this.messageType = messageType;
+        this.senderID = senderID;
+    }
+
+    public static ChatMessageV2 fromDTO(ChatMessageRequest chatMessageRequest) {
+        return ChatMessageV2.builder()
+                .roomId(chatMessageRequest.getRoomId())
+                .message(chatMessageRequest.getMessage())
+                .messageType(chatMessageRequest.getType().getValue())
+                .senderID(chatMessageRequest.getSender().getUserId())
+                .build();
+    }
+
+    public static ChatMessageV2 initChatRoom(User roomMaker, Long roomId) {
+        return ChatMessageV2.builder()
+                .roomId(roomId)
+                .message(roomMaker.getNickname() + "님이 채팅방을 개설하였습니다.")
+                .messageType("ENTER")
+                .senderID(roomMaker.getId())
+                .build();
+    }
+
+    public void readMessage() {
+        this.isRead = 1;
+    }
+}

--- a/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2Repository.java
+++ b/src/main/java/com/example/matchup/matchupbackend/mongodb/ChatMessageV2Repository.java
@@ -1,0 +1,12 @@
+package com.example.matchup.matchupbackend.mongodb;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface ChatMessageV2Repository extends MongoRepository<ChatMessageV2, String> {
+    Slice<ChatMessageV2> findByRoomIdOrderBySendTime(Long roomId, Pageable pageable);
+    List<ChatMessageV2> findByRoomId(Long roomId);
+}

--- a/src/main/java/com/example/matchup/matchupbackend/service/ChatServiceV2.java
+++ b/src/main/java/com/example/matchup/matchupbackend/service/ChatServiceV2.java
@@ -1,0 +1,167 @@
+package com.example.matchup.matchupbackend.service;
+
+import com.example.matchup.matchupbackend.dto.request.chat.ChatMessageRequest;
+import com.example.matchup.matchupbackend.dto.response.chat.SliceChatMessageResponseV2;
+import com.example.matchup.matchupbackend.dto.response.chat.SliceChatRoomResponse;
+import com.example.matchup.matchupbackend.entity.ChatRoom;
+import com.example.matchup.matchupbackend.entity.User;
+import com.example.matchup.matchupbackend.entity.UserChatRoom;
+import com.example.matchup.matchupbackend.entity.UserPosition;
+import com.example.matchup.matchupbackend.error.exception.InvalidValueEx.InvalidChatException;
+import com.example.matchup.matchupbackend.error.exception.ResourceNotFoundEx.UserNotFoundException;
+import com.example.matchup.matchupbackend.global.config.jwt.TokenProvider;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2;
+import com.example.matchup.matchupbackend.mongodb.ChatMessageV2Repository;
+import com.example.matchup.matchupbackend.repository.ChatRoomRepository;
+import com.example.matchup.matchupbackend.repository.UserChatRoomRepository;
+import com.example.matchup.matchupbackend.repository.user.UserRepository;
+import com.example.matchup.matchupbackend.repository.userposition.UserPositionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatServiceV2 {
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final ChatMessageV2Repository chatMessageV2Repository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserChatRoomRepository userChatRoomRepository;
+    private final UserPositionRepository userPositionRepository;
+
+    /**
+     * 채팅 메세지를 MongoDB에 저장
+     */
+    @Transactional
+    public void saveChatMessage(ChatMessageRequest chatMessageRequest) {
+        ChatMessageV2 chatMessage = ChatMessageV2.fromDTO(chatMessageRequest);
+        chatMessageV2Repository.save(chatMessage);
+    }
+
+    /**
+     * 1대1 채팅방 생성
+     */
+    @Transactional
+    public Long create1To1Room(String authorizationHeader, Long receiverId) {
+        Long userId = tokenProvider.getUserId(authorizationHeader, "create1To1Room");
+        if (userId == receiverId) throw new InvalidChatException("자기 자신과는 채팅방을 생성할 수 없습니다.", "userID: " + userId);
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저입니다."));
+        User opponent = userRepository.findById(receiverId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저입니다."));
+        ChatRoom chatRoom = ChatRoom.make1to1ChatRoom(user.getNickname());
+        ChatRoom save = chatRoomRepository.save(chatRoom);
+        link1To1RoomToUser(chatRoom, user, opponent);
+        makeInitialChat(user, save.getId());
+        log.info("userID: " + userId + " 님이 " + "userID: " + receiverId + "와 1대1 채팅방을 생성하였습니다.");
+        return chatRoom.getId();
+    }
+
+    /**
+     * 1대1 채팅방을 유저에게 연결
+     */
+    @Transactional
+    public void link1To1RoomToUser(ChatRoom chatRoom, User user, User receiver) {
+        UserChatRoom userChatRoom = UserChatRoom.createUserChatRoom(user, receiver, chatRoom);
+        UserChatRoom receiverChatRoom = UserChatRoom.createUserChatRoom(receiver, user, chatRoom);
+        userChatRoomRepository.save(userChatRoom);
+        userChatRoomRepository.save(receiverChatRoom);
+    }
+
+    /**
+     * 채팅방 생성시 초기 메세지 생성
+     */
+    @Transactional
+    public void makeInitialChat(User roomMaker, Long roomId) {
+        chatMessageV2Repository.save(ChatMessageV2.initChatRoom(roomMaker, roomId));
+    }
+
+    /**
+     * 이미 유저와 만들어진 채팅방이 있는지 확인
+     */
+    public Long getChatRoomIdIfExist(String myToken, Long opponentId) {
+        Long myId = tokenProvider.getUserId(myToken, "isExistChatRoom");
+        Optional<UserChatRoom> myUserChatRoom = userChatRoomRepository.findUserChatRoomJoinChatRoomBy(myId, opponentId);
+        if (myUserChatRoom.isEmpty()) {
+            return 0L;
+        }
+        return myUserChatRoom.get().getChatRoom().getId();
+    }
+
+    /**
+     * 채팅방 최근 메세지 보기
+     */
+    public SliceChatMessageResponseV2 showMessages(String token, Long roomId, Pageable pageable) {
+        Long myId = tokenProvider.getUserId(token, "showMessages");
+        Slice<ChatMessageV2> sortChatMessageByCreatedAt = chatMessageV2Repository.findByRoomIdOrderBySendTime(roomId, pageable);
+        UserChatRoom userChatRoom = userChatRoomRepository.findJoinOpponentByChatRoomId(roomId, myId)
+                .orElseThrow(() -> new InvalidChatException("채팅방의 상대 유저가 존재하지 않습니다."));
+        List<UserPosition> userPosition = userPositionRepository.findAllByUser(userChatRoom.getOpponent());
+        return SliceChatMessageResponseV2.from(myId, sortChatMessageByCreatedAt, userChatRoom.getOpponent(), getMaxLevel(userPosition));
+    }
+
+    private UserPosition getMaxLevel(List<UserPosition> userPosition) {
+        if(userPosition.isEmpty()) {
+            return UserPosition.builder().typeLevel(0).build();
+        }
+        return userPosition.stream()
+                .max(Comparator.comparing(UserPosition::getTypeLevel))
+                .orElseThrow(() -> new InvalidChatException("getMaxLevel"));
+    }
+
+    /**
+     * 상대방이 보낸 메세지만 읽음 처리
+     */
+    @Transactional
+    public void makeMessageRead(Long myId, List<ChatMessageV2> chatMessageList) {
+        chatMessageList.forEach(chatMessage -> {
+            if (!chatMessage.getSenderID().equals(myId)) {
+                chatMessage.readMessage();
+            }
+        });
+        chatMessageV2Repository.saveAll(chatMessageList);
+    }
+
+    /**
+     * 채팅방 목록 보기
+     */
+    public SliceChatRoomResponse getSliceChatRoomResponse(String authorizationHeader, Pageable pageable) {
+        Long myId = tokenProvider.getUserId(authorizationHeader, "getSliceChatRoomResponse");
+        Slice<UserChatRoom> userChatRoomList = userChatRoomRepository.findJoinChatRoomAndUserByUserId(myId, pageable);
+        Slice<UserChatRoom> updateRoomList = updateRoomInfo(myId, userChatRoomList);
+        List<User> opponentList = updateRoomList.getContent().stream().map(UserChatRoom::getUser).collect(Collectors.toList());
+        List<UserPosition> userPositionList = userPositionRepository.findAllJoinUserByUserList(opponentList);
+        return SliceChatRoomResponse.from(myId, updateRoomList, mapUserPositionToUser(userPositionList));
+    }
+
+    private Map<User, Optional<UserPosition>> mapUserPositionToUser(List<UserPosition> userPositionList) {
+        Map<User, Optional<UserPosition>> userPositionMap = new HashMap<>();
+        userPositionList.forEach(userPosition -> {
+            userPositionMap.put(userPosition.getUser(), Optional.ofNullable(userPosition));
+        });
+        return userPositionMap;
+    }
+
+    /**
+     * 채팅방 정보 업데이트
+     * 채팅방을 열면 채팅방의 정보를 업데이트 한다.
+     */
+    @Transactional
+    public Slice<UserChatRoom> updateRoomInfo(Long myId, Slice<UserChatRoom> userChatRoomList) {
+        userChatRoomList.forEach(userChatRoom -> {
+            ChatRoom chatRoom = userChatRoom.getChatRoom();
+            List<ChatMessageV2> chatMessageList = chatMessageV2Repository.findByRoomId(userChatRoom.getChatRoom().getId());
+            userChatRoom.updateRoomInfoV2(myId, chatMessageList);
+            chatRoom.updateRoomInfoV2(chatMessageList);
+        });
+        return userChatRoomList;
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- 프론트와 통신하는 DTO와 기능, DB 구조는 그대로 두고 DB만 마이그레이션 (DynamoDB 에서 MongoDB)

### 프론트에서 변경 해야하는 상황
- /api/v1/chat 으로 시작 하는 URI를 /api/v2/chat으로 변경
- 웹 소캣 연결 후 메세지 전송 엔드포인트를 /chat/{roomId} 에서 /mongodb/chat/{roomId}로 변경

### 할 일
- 웹소캣 연결 후 채팅 메시지 저장은 추가 되는지 QA #208 